### PR TITLE
Use correct format for auth header

### DIFF
--- a/apiV2/conf/apiv2.routes
+++ b/apiV2/conf/apiv2.routes
@@ -4,11 +4,18 @@
 
 ###
 #  summary: Creates an API session
+#  description: >-
+#    Creates a new API session. Pass an API key to create an authenticated
+#    session, pass an API key in the Authorization header, to create a public session,
+#    don't pass an Authorization header.
 #  tags:
 #    - Authentification
 #  security:
 #    - Key: []
 #    - {}
+#  parameters:
+#    - name: fake
+#      description: Used in testing. Can normally be ignored.
 #  responses:
 #    200:
 #      description: Ok

--- a/extra/apiV2.http
+++ b/extra/apiV2.http
@@ -14,7 +14,7 @@ Accept: application/json
 ### Authenticate key
 POST http://localhost:9000/api/v2/authenticate
 Accept: application/json
-Authorization: ApiKey {{api_key}}
+Authorization: OreApi apikey={{api_key}}
 
 > {% client.global.set("api_session", response.body.session); %}
 
@@ -33,7 +33,7 @@ Accept: application/json
 
 ### Create a new key
 POST http://localhost:9000/api/v2/keys
-Authorization: ApiSession {{api_session}}
+Authorization: OreApi session={{api_session}}
 Accept: application/json
 Content-Type: application/json
 
@@ -49,7 +49,7 @@ Content-Type: application/json
 
 ### Delete a key
 DELETE http://localhost:9000/api/v2/keys?name=Foo
-Authorization: ApiSession {{api_session}}
+Authorization: OreApi session={{api_session}}
 Accept: application/json
 Content-Type: application/json
 
@@ -57,37 +57,37 @@ Content-Type: application/json
 
 ### Get current permissions
 GET http://localhost:9000/api/v2/permissions
-Authorization: ApiSession {{api_session}}
+Authorization: OreApi session={{api_session}}
 Accept: application/json
 
 ### Project list
 GET http://localhost:9000/api/v2/projects
-Authorization: ApiSession {{api_session}}
+Authorization: OreApi session={{api_session}}
 Accept: application/json
 
 ### Get single project
 GET http://localhost:9000/api/v2/projects/nucleus
-Authorization: ApiSession {{api_session}}
+Authorization: OreApi session={{api_session}}
 Accept: application/json
 
 ### Get project members
 GET http://localhost:9000/api/v2/projects/nucleus/members
-Authorization: ApiSession {{api_session}}
+Authorization: OreApi session={{api_session}}
 Accept: application/json
 
 ### Get project versions
 GET http://localhost:9000/api/v2/projects/nucleus/versions
-Authorization: ApiSession {{api_session}}
+Authorization: OreApi session={{api_session}}
 Accept: application/json
 
 ### Get single project versions
 GET http://localhost:9000/api/v2/projects/nucleus/versions/1.9.0-S7.1
-Authorization: ApiSession {{api_session}}
+Authorization: OreApi session={{api_session}}
 Accept: application/json
 
 ### Get user
 GET http://localhost:9000/api/v2/users/Spongie
-Authorization: ApiSession {{api_session}}
+Authorization: OreApi session={{api_session}}
 Accept: application/json
 
 ###

--- a/ore/app/views/swagger.scala.html
+++ b/ore/app/views/swagger.scala.html
@@ -62,7 +62,7 @@ Mostly copied from swagger-ui's index file
                         requestInterceptor: (req) => {
                             if (!req.loadSpec) {
                                 const promise = getApiSession().then((session) => {
-                                    req.headers.authorization = 'ApiSession ' + session;
+                                    req.headers.authorization = 'OreApi session=' + session;
                                     return req;
                                 });
                                 // Workaround for fixing the curl URL

--- a/ore/conf/swagger.yml
+++ b/ore/conf/swagger.yml
@@ -78,10 +78,20 @@ components:
   securitySchemes:
     Session:
       type: http
-      scheme: ApiSession
+      scheme: OreApi
+      description: >-
+        Authentication using an API session. The session is passed as part of the
+        Authorization header in the form `Authorization: OreApi session="<my session here>"`.
+        You can get a session from the authentication endpoint.
     Key:
       type: http
-      scheme: ApiKey
+      scheme: OreApi
+      description: >-
+        Authentication using an API key. This should in most cases not be a
+        request that you execute repeatedly. The key is passed as part of the
+        Authorization header in the form `Authorization: OreApi apikey="<my key here>"`.
+        You can get an API key either from the web interface, or using the
+        create key endpoint with a more powerful key.
   responses:
     UnauthorizedError:
       description: Api session missing, invalid or expired

--- a/ore/public/javascripts/apiRequests.js
+++ b/ore/public/javascripts/apiRequests.js
@@ -13,14 +13,15 @@ function apiV2Request(url, method = "GET", data = {}) {
     return getApiSession().then(function (session) {
         return new Promise(function (resolve, reject) {
             const isFormData = data instanceof FormData;
+            const isBodyRequest = (method === "POST" || method === "PUT" || method === "PATCH");
 
             $.ajax({
                 url: '/api/v2/' + url,
                 method: method,
                 dataType: 'json',
                 contentType: isFormData ? false : 'application/json',
-                data: data,
-                processData: isFormData ? false : undefined,
+                data: isBodyRequest && !isFormData ? JSON.stringify(data) : data,
+                processData: !(isFormData || isBodyRequest),
                 headers: {'Authorization': 'OreApi session=' + session}
             }).done(function (data) {
                 resolve(data);

--- a/ore/public/javascripts/apiRequests.js
+++ b/ore/public/javascripts/apiRequests.js
@@ -21,7 +21,7 @@ function apiV2Request(url, method = "GET", data = {}) {
                 contentType: isFormData ? false : 'application/json',
                 data: data,
                 processData: isFormData ? false : undefined,
-                headers: {'Authorization': 'ApiSession ' + session}
+                headers: {'Authorization': 'OreApi session=' + session}
             }).done(function (data) {
                 resolve(data);
             }).fail(function (xhr) {


### PR DESCRIPTION
Fixes the issue Phit pointed out about Ore not respecting the spec in regards to the Authorization header.

It's now `Authorization: OreApi session=foo` and `Authorization: OreApi apikey=bar`