### PR TITLE
Add a sitemap to Ore

### DIFF
--- a/ore/app/OreApplicationLoader.scala
+++ b/ore/app/OreApplicationLoader.scala
@@ -122,6 +122,7 @@ class OreComponents(context: ApplicationLoader.Context)
     }.flatten
   }
 
+  lazy val assetsProvider: Provider[Assets] = () => assets
   lazy val routerProvider: Provider[Router] = () => router
 
   lazy val optionalSourceMapper: OptionalSourceMapper = new OptionalSourceMapper(devContext.map(_.sourceMapper))

--- a/ore/app/OreApplicationLoader.scala
+++ b/ore/app/OreApplicationLoader.scala
@@ -122,7 +122,6 @@ class OreComponents(context: ApplicationLoader.Context)
     }.flatten
   }
 
-  lazy val assetsProvider: Provider[Assets] = () => assets
   lazy val routerProvider: Provider[Router] = () => router
 
   lazy val optionalSourceMapper: OptionalSourceMapper = new OptionalSourceMapper(devContext.map(_.sourceMapper))

--- a/ore/app/controllers/Application.scala
+++ b/ore/app/controllers/Application.scala
@@ -426,7 +426,8 @@ final class Application @Inject()(forms: OreForms)(
   val globalSitemap: Action[AnyContent] = Action { implicit requests =>
     Ok(
       Sitemap.asString(
-        Sitemap.Entry(routes.Application.showHome()),
+        Sitemap.Entry(routes.Application.showHome(), changeFreq = Some(Sitemap.ChangeFreq.Hourly)),
+        Sitemap.Entry(routes.Users.showAuthors(None, None), changeFreq = Some(Sitemap.ChangeFreq.Monthly)),
         Sitemap.Entry(routes.Application.swagger())
       )
     ).as("application/xml")

--- a/ore/app/controllers/Application.scala
+++ b/ore/app/controllers/Application.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import java.io.StringWriter
 import java.sql.Timestamp
 import java.time.temporal.ChronoUnit
 import java.time.{Instant, LocalDate}
@@ -28,7 +29,7 @@ import ore.models.user._
 import ore.models.user.role._
 import ore.permission._
 import ore.permission.role.{Role, RoleCategory}
-import util.UserActionLogger
+import util.{Sitemap, UserActionLogger}
 import util.syntax._
 import views.{html => views}
 
@@ -398,5 +399,36 @@ final class Application @Inject()(forms: OreForms)(
 
   def swagger(): Action[AnyContent] = OreAction { implicit request =>
     Ok(views.swagger())
+  }
+
+  def sitemapIndex(): Action[AnyContent] = Action.asyncF { implicit request =>
+    service.runDbCon(AppQueries.sitemapIndexUsers.to[Vector]).map { users =>
+      def userSitemap(user: String) =
+        <sitemap>
+          <loc>{routes.Users.userSitemap(user).absoluteURL()}</loc>
+        </sitemap>
+
+      val sitemapIndex =
+        <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          {users.map(userSitemap)}
+          <sitemap>
+            <loc>{routes.Application.globalSitemap().absoluteURL()}</loc>
+          </sitemap>
+        </sitemapindex>
+
+      val writer = new StringWriter()
+      xml.XML.write(writer, sitemapIndex, "UTF-8", xmlDecl = true, null)
+
+      Ok(writer.toString).as("application/xml")
+    }
+  }
+
+  val globalSitemap: Action[AnyContent] = Action { implicit requests =>
+    Ok(
+      Sitemap.asString(
+        Sitemap.Entry(routes.Application.showHome()),
+        Sitemap.Entry(routes.Application.swagger())
+      )
+    ).as("application/xml")
   }
 }

--- a/ore/app/controllers/Application.scala
+++ b/ore/app/controllers/Application.scala
@@ -432,4 +432,21 @@ final class Application @Inject()(forms: OreForms)(
       )
     ).as("application/xml")
   }
+
+  val robots: Action[AnyContent] = Action {
+    Ok(s"""user-agent: *
+          |Disallow: /*/settings/*
+          |Disallow: /*/notifications/*
+          |Disallow: /staff$$
+          |Disallow: /organizations/*
+
+          |Allow: /*
+          |Allow: /*/$$
+          |Allow: /*/*/$$
+          |Allow: /*/*/pages/*/$$
+          |Allow: /*/*/versions/*/$$
+          |Disallow: /
+          |Sitemap: ${config.app.baseUrl}/sitemap.xml
+      """.stripMargin).as("text/plain")
+  }
 }

--- a/ore/app/controllers/Application.scala
+++ b/ore/app/controllers/Application.scala
@@ -432,4 +432,6 @@ final class Application @Inject()(forms: OreForms)(
       )
     ).as("application/xml")
   }
+
+  val robots: Action[AnyContent] = TODO
 }

--- a/ore/app/controllers/Application.scala
+++ b/ore/app/controllers/Application.scala
@@ -432,6 +432,4 @@ final class Application @Inject()(forms: OreForms)(
       )
     ).as("application/xml")
   }
-
-  val robots: Action[AnyContent] = TODO
 }

--- a/ore/app/controllers/Users.scala
+++ b/ore/app/controllers/Users.scala
@@ -15,20 +15,20 @@ import ore.data.Prompt
 import ore.db.access.ModelView
 import ore.db.impl.OrePostgresDriver.api._
 import ore.db.impl.query.UserQueries
-import ore.db.impl.schema.{ApiKeyTable, UserTable}
+import ore.db.impl.schema.{ApiKeyTable, PageTable, ProjectTableMain, UserTable, VersionTable}
 import ore.db.{DbRef, Model}
 import ore.models.project.ProjectSortingStrategy
 import ore.models.user.notification.{InviteFilter, NotificationFilter}
 import ore.models.user.{FakeUser, _}
 import ore.permission.Permission
 import ore.permission.role.Role
-import util.UserActionLogger
+import util.{Sitemap, UserActionLogger}
 import util.syntax._
 import views.{html => views}
 
 import cats.syntax.all._
 import zio.interop.catz._
-import zio.{IO, Task, ZIO}
+import zio.{IO, Task, UIO, ZIO}
 
 /**
   * Controller for general user actions.
@@ -345,4 +345,83 @@ class Users @Inject()(
         }
       } else IO.fail(Forbidden)
     }
+
+  import controllers.project.{routes => projectRoutes}
+
+  private val projectEndpoints: Seq[(String, String) => Call] = Seq(
+    projectRoutes.Projects.show,
+    projectRoutes.Projects.showStargazers(_, _, None),
+    projectRoutes.Projects.showWatchers(_, _, None),
+    projectRoutes.Projects.showDiscussion
+  )
+
+  def userSitemap(user: String): Action[AnyContent] = Action.asyncF { implicit request =>
+    val projectsQuery = for {
+      u <- TableQuery[UserTable]
+      p <- TableQuery[ProjectTableMain] if u.id === p.userId
+      if u.name === user
+    } yield p.slug
+
+    val versionQuery = for {
+      u  <- TableQuery[UserTable]
+      p  <- TableQuery[ProjectTableMain] if u.id === p.userId
+      pv <- TableQuery[VersionTable] if p.id === pv.projectId
+      if u.name === user
+    } yield (p.slug, pv.versionString)
+
+    val pageQuery = for {
+      u  <- TableQuery[UserTable]
+      p  <- TableQuery[ProjectTableMain] if u.id === p.userId
+      pp <- TableQuery[PageTable] if p.id === pp.projectId
+      if u.name === user
+    } yield (p.slug, pp.name)
+
+    for {
+      projectsFiber <- service.runDBIO(projectsQuery.result).fork
+      versionsFiber <- service.runDBIO(versionQuery.result).fork
+      pagesFiber    <- service.runDBIO(pageQuery.result).fork
+      userExists    <- ModelView.now(User).exists(_.name === user)
+      res <- {
+        if (userExists) {
+          val projectsF = projectsFiber.join
+          val versionsF = versionsFiber.join
+          val pagesF    = pagesFiber.join
+
+          //IntelliJ is stupid
+          projectsF <&> versionsF <&> pagesF: UIO[((Seq[String], Seq[(String, String)]), Seq[(String, String)])]
+        } else {
+          versionsFiber.interrupt &>
+            projectsFiber.interrupt &>
+            pagesFiber.interrupt &>
+            ZIO.fail(NotFound): IO[Result, Nothing]
+        }
+      }
+      ((projects, versions), pages) = res
+    } yield {
+      val projectEntries = for {
+        project  <- projects
+        endpoint <- projectEndpoints
+      } yield Sitemap.Entry(endpoint(user, project))
+
+      val versionEntries =
+        for ((project, version) <- versions)
+          yield Sitemap.Entry(
+            projectRoutes.Versions.show(user, project, version)
+          )
+
+      val pageEntries =
+        for ((project, page) <- pages)
+          yield Sitemap.Entry(
+            projectRoutes.Pages.show(user, project, page)
+          )
+
+      Ok(
+        Sitemap.asString(
+          projectEntries ++
+            versionEntries ++
+            pageEntries :+ Sitemap.Entry(routes.Users.showProjects(user, None)): _*
+        )
+      ).as("application/xml")
+    }
+  }
 }

--- a/ore/app/controllers/Users.scala
+++ b/ore/app/controllers/Users.scala
@@ -348,11 +348,6 @@ class Users @Inject()(
 
   import controllers.project.{routes => projectRoutes}
 
-  private val projectEndpoints: Seq[((String, String) => Call, Option[Sitemap.ChangeFreq])] = Seq(
-    (projectRoutes.Projects.show, None),
-    (projectRoutes.Versions.showList, Some(Sitemap.ChangeFreq.Daily))
-  )
-
   def userSitemap(user: String): Action[AnyContent] = Action.asyncF { implicit request =>
     val projectsQuery = for {
       u <- TableQuery[UserTable]
@@ -396,10 +391,7 @@ class Users @Inject()(
       }
       ((projects, versions), pages) = res
     } yield {
-      val projectEntries = for {
-        project  <- projects
-        endpoint <- projectEndpoints
-      } yield Sitemap.Entry(endpoint._1(user, project), changeFreq = endpoint._2)
+      val projectEntries = for (project <- projects) yield Sitemap.Entry(projectRoutes.Projects.show(user, project))
 
       val versionEntries =
         for ((project, version) <- versions)

--- a/ore/app/controllers/Users.scala
+++ b/ore/app/controllers/Users.scala
@@ -350,10 +350,7 @@ class Users @Inject()(
 
   private val projectEndpoints: Seq[((String, String) => Call, Option[Sitemap.ChangeFreq])] = Seq(
     (projectRoutes.Projects.show, None),
-    (projectRoutes.Versions.showList, Some(Sitemap.ChangeFreq.Daily)),
-    (projectRoutes.Projects.showStargazers(_, _, None), Some(Sitemap.ChangeFreq.Monthly)),
-    (projectRoutes.Projects.showWatchers(_, _, None), Some(Sitemap.ChangeFreq.Monthly)),
-    (projectRoutes.Projects.showDiscussion, None)
+    (projectRoutes.Versions.showList, Some(Sitemap.ChangeFreq.Daily))
   )
 
   def userSitemap(user: String): Action[AnyContent] = Action.asyncF { implicit request =>

--- a/ore/app/db/impl/query/AppQueries.scala
+++ b/ore/app/db/impl/query/AppQueries.scala
@@ -177,4 +177,11 @@ object AppQueries extends WebDoobieOreProtocol {
           |  WHERE vc.resolved_at IS NULL
           |    AND p.visibility = 3""".stripMargin.query[ProjectNeedsApproval]
   }
+
+  val sitemapIndexUsers: Query0[String] = {
+    sql"""|SELECT u.name
+          |    FROM users u
+          |    ORDER BY (SELECT COUNT(*) FROM project_members_all pma WHERE pma.user_id = u.id) DESC
+          |    LIMIT 49000""".stripMargin.query[String]
+  }
 }

--- a/ore/app/util/Sitemap.scala
+++ b/ore/app/util/Sitemap.scala
@@ -1,0 +1,62 @@
+package util
+
+import java.io.StringWriter
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+import scala.collection.immutable
+import scala.xml.{Elem, NodeSeq, XML}
+
+import play.api.mvc.{Call, RequestHeader}
+
+import enumeratum.values.{StringEnum, StringEnumEntry}
+
+object Sitemap {
+  sealed abstract class ChangeFreq(val value: String) extends StringEnumEntry
+  object ChangeFreq extends StringEnum[ChangeFreq] {
+    case object Always  extends ChangeFreq("always")
+    case object Hourly  extends ChangeFreq("hourly")
+    case object Daily   extends ChangeFreq("daily")
+    case object Weekly  extends ChangeFreq("weekly")
+    case object Monthly extends ChangeFreq("monthly")
+    case object Yearly  extends ChangeFreq("yearly")
+    case object Never   extends ChangeFreq("never")
+
+    override def values: immutable.IndexedSeq[ChangeFreq] = findValues
+  }
+
+  private val xmlDatetimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX")
+
+  case class Entry(
+      loc: Call,
+      lastmod: Option[LocalDateTime] = None,
+      changeFreq: Option[ChangeFreq] = None,
+      priority: Option[Double] = None
+  ) {
+
+    def toXML(implicit request: RequestHeader): Elem =
+      <url>
+        <loc>{loc.absoluteURL()}</loc>
+        {lastmod.fold(NodeSeq.Empty)(v => <lastmod>{xmlDatetimeFormat.format(v)}</lastmod>)}
+        {changeFreq.fold(NodeSeq.Empty)(v => <changefreq>{v.value}</changefreq>)}
+        {priority.fold(NodeSeq.Empty)(v => <priority>{v}</priority>)}
+      </url>
+  }
+
+  def apply(entries: Entry*)(implicit request: RequestHeader): Elem = {
+    require(entries.length < 50000)
+
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      {entries.map(_.toXML)}
+    </urlset>
+  }
+
+  def asString(entries: Entry*)(implicit requests: RequestHeader): String = {
+    val xml = apply(entries: _*)
+
+    val writer = new StringWriter()
+    XML.write(writer, xml, "UTF-8", xmlDecl = true, null)
+
+    writer.toString
+  }
+}

--- a/ore/conf/routes
+++ b/ore/conf/routes
@@ -61,6 +61,7 @@ POST    /verify                                                     @controllers
 GET     /javascriptRoutes                                           @controllers.Application.javascriptRoutes
 GET     /global-sitemap.xml                                         @controllers.Application.globalSitemap
 GET     /sitemap.xml                                                @controllers.Application.sitemapIndex()
+GET     /robots.txt                                                 @controllers.Application.robots()
 
 # ---------- Projects ----------
 

--- a/ore/conf/routes
+++ b/ore/conf/routes
@@ -61,7 +61,7 @@ POST    /verify                                                     @controllers
 GET     /javascriptRoutes                                           @controllers.Application.javascriptRoutes
 GET     /global-sitemap.xml                                         @controllers.Application.globalSitemap
 GET     /sitemap.xml                                                @controllers.Application.sitemapIndex()
-GET     /robots.txt                                                 @controllers.Assets.at(path="/public", file="robots.txt")
+GET     /robots.txt                                                 @controllers.Application.robots()
 
 # ---------- Projects ----------
 

--- a/ore/conf/routes
+++ b/ore/conf/routes
@@ -59,6 +59,8 @@ GET     /login                                                      @controllers
 GET     /logout                                                     @controllers.Users.logOut()
 POST    /verify                                                     @controllers.Users.verify(returnPath: Option[String])
 GET     /javascriptRoutes                                           @controllers.Application.javascriptRoutes
+GET     /global-sitemap.xml                                         @controllers.Application.globalSitemap
+GET     /sitemap.xml                                                @controllers.Application.sitemapIndex()
 
 # ---------- Projects ----------
 
@@ -91,6 +93,7 @@ POST    /notifications/read/:id                                     @controllers
 POST    /prompts/read/:id                                           @controllers.Users.markPromptRead(id: Int)
 
 GET     /:user                                                      @controllers.Users.showProjects(user, page: Option[Int])
+GET     /:user/sitemap.xml                                          @controllers.Users.userSitemap(user)
 POST    /:user/settings/tagline                                     @controllers.Users.saveTagline(user)
 POST    /:user/settings/lock/:locked                                @controllers.Users.setLocked(user, locked: Boolean, sso: Option[String], sig: Option[String])
 GET     /:user/settings/apiKeys                                     @controllers.Users.editApiKeys(user)

--- a/ore/conf/routes
+++ b/ore/conf/routes
@@ -61,7 +61,7 @@ POST    /verify                                                     @controllers
 GET     /javascriptRoutes                                           @controllers.Application.javascriptRoutes
 GET     /global-sitemap.xml                                         @controllers.Application.globalSitemap
 GET     /sitemap.xml                                                @controllers.Application.sitemapIndex()
-GET     /robots.txt                                                 @controllers.Application.robots()
+GET     /robots.txt                                                 @controllers.Assets.at(path="/public", file="robots.txt")
 
 # ---------- Projects ----------
 

--- a/ore/public/robots.txt
+++ b/ore/public/robots.txt
@@ -1,0 +1,14 @@
+user-agent: *
+
+Disallow: /*/settings/*
+Disallow: /*/notifications/*
+Disallow: /staff$
+Disallow: /organizations/*
+
+Allow: /$
+Allow: /*/$
+Allow: /*/*/$
+Allow: /*/*/pages/*/$
+Allow: /*/*/versions/*/$
+
+Disallow: /

--- a/ore/test/db/AppQueriesSpec.scala
+++ b/ore/test/db/AppQueriesSpec.scala
@@ -75,4 +75,8 @@ class AppQueriesSpec extends DbSpec {
   test("GetVisibilityWaitingProject") {
     check(AppQueries.getVisibilityWaitingProject)
   }
+
+  test("SitemapIndexUsers") {
+    check(AppQueries.sitemapIndexUsers)
+  }
 }


### PR DESCRIPTION
Adds sitemap generation to Ore

One last question we need to answer is if we want to set any extra fields in the sitemap like change frequency or priority.

Also fixes the author list to use the much better `project_members_all` view to determine how many projects a user works on.