### PR TITLE
Add session invalidation tools

### DIFF
--- a/apiV2/app/db/impl/query/APIV2Queries.scala
+++ b/apiV2/app/db/impl/query/APIV2Queries.scala
@@ -63,6 +63,7 @@ object APIV2Queries extends WebDoobieOreProtocol {
           |       ak.owner_id,
           |       ak.token,
           |       ak.raw_key_permissions,
+          |       aks.token,
           |       aks.expires,
           |       CASE
           |           WHEN u.id IS NULL THEN 1::BIT(64)

--- a/apiV2/conf/apiv2.routes
+++ b/apiV2/conf/apiv2.routes
@@ -64,7 +64,7 @@ POST    /authenticate/user                                   @controllers.apiv2.
 #    403:
 #      $ref: '#/components/responses/ForbiddenError'
 ###
-DELETE /sessions/:session                                    @controllers.apiv2.ApiV2Controller.deleteSession(session)
+DELETE /sessions/current                                     @controllers.apiv2.ApiV2Controller.deleteSession(session)
 
 ###
 #  summary: Creates an API key

--- a/apiV2/conf/apiv2.routes
+++ b/apiV2/conf/apiv2.routes
@@ -64,7 +64,7 @@ POST    /authenticate/user                                   @controllers.apiv2.
 #    403:
 #      $ref: '#/components/responses/ForbiddenError'
 ###
-DELETE /sessions/current                                     @controllers.apiv2.ApiV2Controller.deleteSession(session)
+DELETE /sessions/current                                     @controllers.apiv2.ApiV2Controller.deleteSession()
 
 ###
 #  summary: Creates an API key

--- a/apiV2/conf/apiv2.routes
+++ b/apiV2/conf/apiv2.routes
@@ -16,6 +16,11 @@
 #  parameters:
 #    - name: fake
 #      description: Used in testing. Can normally be ignored.
+#    - name: expiresIn
+#      description: >-
+#        How many seconds this session should be valid for. This is merely a
+#        suggesion, and Ore may choose to choose a different expiration if it
+#        wants to.
 #  responses:
 #    200:
 #      description: Ok
@@ -32,10 +37,34 @@
 #            type: string
 ###
 +nocsrf
-POST    /authenticate                                        @controllers.apiv2.ApiV2Controller.authenticate(fake: Boolean ?= false)
+POST    /authenticate                                        @controllers.apiv2.ApiV2Controller.authenticate(fake: Boolean ?= false, expiresIn: Option[Long] = None)
 
 ### NoDocs ###
 POST    /authenticate/user                                   @controllers.apiv2.ApiV2Controller.authenticateUser()
+
+###
+#  summary: Invalidates an existing API session.
+#  description: >-
+#    Invalidates the passed in API session. This endpoint must use the API
+#    session to validate as it's session.
+#  tags:
+#    - Keys
+#  parameters:
+#    - name: session
+#      description: The name of the key to delete
+#  responses:
+#    204:
+#      description: Session invalidated
+#    400:
+#      description: >-
+#        Sent if the session you used to make the request doesn't
+#        match the one you want to delete.
+#    401:
+#      $ref: '#/components/responses/UnauthorizedError'
+#    403:
+#      $ref: '#/components/responses/ForbiddenError'
+###
+DELETE /sessions/:session                                    @controllers.apiv2.ApiV2Controller.deleteSession(session)
 
 ###
 #  summary: Creates an API key

--- a/apiV2/conf/apiv2.routes
+++ b/apiV2/conf/apiv2.routes
@@ -18,9 +18,8 @@
 #      description: Used in testing. Can normally be ignored.
 #    - name: expiresIn
 #      description: >-
-#        How many seconds this session should be valid for. This is merely a
-#        suggesion, and Ore may choose to choose a different expiration if it
-#        wants to.
+#        How many seconds this session should be valid for. If the duration
+#        can't be used for whatever reason, Ore will reply with a 400 response.
 #  responses:
 #    200:
 #      description: Ok
@@ -28,7 +27,8 @@
 #        application/json:
 #          schema:
 #            $ref: '#/components/schemas/controllers.apiv2.ApiV2Controller.ReturnedApiSession'
-#
+#    400:
+#      description: Sent if the requested expiration can't be used.
 #    401:
 #      description: Api key missing or invalid
 #      headers:
@@ -56,9 +56,7 @@ POST    /authenticate/user                                   @controllers.apiv2.
 #    204:
 #      description: Session invalidated
 #    400:
-#      description: >-
-#        Sent if the session you used to make the request doesn't
-#        match the one you want to delete.
+#      description: Sent if this request was not made with a session.
 #    401:
 #      $ref: '#/components/responses/UnauthorizedError'
 #    403:

--- a/orePlayCommon/app/controllers/sugar/Requests.scala
+++ b/orePlayCommon/app/controllers/sugar/Requests.scala
@@ -1,7 +1,5 @@
 package controllers.sugar
 
-import scala.language.higherKinds
-
 import java.time.Instant
 
 import play.api.mvc.{Request, WrappedRequest}
@@ -25,7 +23,13 @@ import org.slf4j.MDC
   */
 object Requests {
 
-  case class ApiAuthInfo(user: Option[Model[User]], key: Option[ApiKey], expires: Instant, globalPerms: Permission)
+  case class ApiAuthInfo(
+      user: Option[Model[User]],
+      key: Option[ApiKey],
+      session: Option[String],
+      expires: Instant,
+      globalPerms: Permission
+  )
 
   case class ApiRequest[A](apiInfo: ApiAuthInfo, request: Request[A]) extends WrappedRequest[A](request) with OreMDC {
     def user: Option[Model[User]] = apiInfo.user


### PR DESCRIPTION
Fixes #913

Adds an endpoint to invalidate sessions, and allows the user to suggest an expiration time when creating a session.