### PR TITLE
Add postfix wildcard matching to search

### DIFF
--- a/apiV2/app/db/impl/query/APIV2Queries.scala
+++ b/apiV2/app/db/impl/query/APIV2Queries.scala
@@ -165,7 +165,7 @@ object APIV2Queries extends WebDoobieOreProtocol {
         Some(fr"EXISTS" ++ Fragments.parentheses(jsSelect))
       } else
         None,
-      query.map(q => fr"p.search_words @@ websearch_to_tsquery($q)"),
+      query.map(q => fr"p.search_words @@ websearch_to_tsquery_postfix('english', $q)"),
       owner.map(o => fr"p.owner_name = $o"),
       visibilityFrag
     )
@@ -192,14 +192,20 @@ object APIV2Queries extends WebDoobieOreProtocol {
   ): Query0[ZIO[Blocking, Nothing, APIV2.Project]] = {
     val ordering = if (orderWithRelevance && query.nonEmpty) {
       val relevance = query.fold(fr"1") { q =>
-        fr"ts_rank(p.search_words, websearch_to_tsquery($q)) DESC"
+        fr"ts_rank(p.search_words, websearch_to_tsquery_postfix('english', $q)) DESC"
       }
+
+      // 1483056000 is the Ore epoch
+      // 86400 seconds to days
+      // 604800‬ seconds to weeks
       order match {
-        case ProjectSortingStrategy.MostStars       => fr"p.stars *" ++ relevance
-        case ProjectSortingStrategy.MostDownloads   => fr"p.downloads*" ++ relevance
-        case ProjectSortingStrategy.MostViews       => fr"p.views *" ++ relevance
-        case ProjectSortingStrategy.Newest          => fr"extract(EPOCH from p.created_at) *" ++ relevance
-        case ProjectSortingStrategy.RecentlyUpdated => fr"extract(EPOCH from p.last_updated) *" ++ relevance
+        case ProjectSortingStrategy.MostStars     => fr"p.stars *" ++ relevance
+        case ProjectSortingStrategy.MostDownloads => fr"(p.downloads / 100) *" ++ relevance
+        case ProjectSortingStrategy.MostViews     => fr"(p.views / 200) *" ++ relevance
+        case ProjectSortingStrategy.Newest =>
+          fr"((extract(EPOCH from p.created_at) - 1483056000) / 86400) *" ++ relevance
+        case ProjectSortingStrategy.RecentlyUpdated =>
+          fr"((extract(EPOCH from p.last_updated) - 1483056000) / 604800) *" ++ relevance
         case ProjectSortingStrategy.OnlyRelevance   => relevance
         case ProjectSortingStrategy.RecentViews     => fr"p.recent_views *" ++ relevance
         case ProjectSortingStrategy.RecentDownloads => fr"p.recent_downloads*" ++ relevance

--- a/ore/conf/evolutions/default/133.sql
+++ b/ore/conf/evolutions/default/133.sql
@@ -5,12 +5,12 @@ CREATE OR REPLACE FUNCTION websearch_to_tsquery_postfix(dictionary REGCONFIG, qu
     LANGUAGE plpgsql AS
 $$
 DECLARE
-    arr  TEXT[]  := regexp_split_to_array(query, '\s+');
-    last TEXT    := websearch_to_tsquery(dictionary, arr[array_length(arr, 1)])::TEXT;
-    init TSQUERY := websearch_to_tsquery(dictionary, regexp_replace(query, '\S+$', ''));
+    arr  TEXT[]  := regexp_split_to_array(query, '\s+');;
+    last TEXT    := websearch_to_tsquery(dictionary, arr[array_length(arr, 1)])::TEXT;;
+    init TSQUERY := websearch_to_tsquery(dictionary, regexp_replace(query, '\S+$', ''));;
 BEGIN
-    RETURN init && to_tsquery(last || ':*');
-END;
+    RETURN init && to_tsquery(last || ':*');;
+END;;
 $$;
 
 # --- !Downs

--- a/ore/conf/evolutions/default/133.sql
+++ b/ore/conf/evolutions/default/133.sql
@@ -1,0 +1,18 @@
+# --- !Ups
+
+CREATE OR REPLACE FUNCTION websearch_to_tsquery_postfix(dictionary REGCONFIG, query TEXT) RETURNS TSQUERY
+    IMMUTABLE STRICT
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    arr  TEXT[]  := regexp_split_to_array(query, '\s+');
+    last TEXT    := websearch_to_tsquery(dictionary, arr[array_length(arr, 1)])::TEXT;
+    init TSQUERY := websearch_to_tsquery(dictionary, regexp_replace(query, '\S+$', ''));
+BEGIN
+    RETURN init && to_tsquery(last || ':*');
+END;
+$$;
+
+# --- !Downs
+
+DROP FUNCTION websearch_to_tsquery_postfix;


### PR DESCRIPTION
Fixes #924 to a reasonable degree. We're not doing full on substring match. The indexes needed for that would probably be a bit too large. We could do a reverse match in the future, but those are hacky, so leaving it out for now.

Also changed the weights for relevance sorting to be better.