### PR TITLE
Disallow / in page name

### DIFF
--- a/oreClient/src/main/assets/pages/project/ProjectDocs.vue
+++ b/oreClient/src/main/assets/pages/project/ProjectDocs.vue
@@ -118,7 +118,7 @@
                                                 @click="resetPutPage">Close
                                         </button>
                                         <button v-if="!newPage" type="button" class="btn btn-danger" @click="deletePage">Delete</button>
-                                        <button :disabled="requestPage.name.includes('/')" type="button" class="btn btn-primary" @click="updateCreatePage">Continue</button>
+                                        <button :disabled="!requestPage.name || requestPage.name.includes('/')" type="button" class="btn btn-primary" @click="updateCreatePage">Continue</button>
                                     </div>
                                 </div>
                             </div>

--- a/oreClient/src/main/assets/pages/project/ProjectDocs.vue
+++ b/oreClient/src/main/assets/pages/project/ProjectDocs.vue
@@ -118,7 +118,7 @@
                                                 @click="resetPutPage">Close
                                         </button>
                                         <button v-if="!newPage" type="button" class="btn btn-danger" @click="deletePage">Delete</button>
-                                        <button type="button" class="btn btn-primary" @click="updateCreatePage">Continue</button>
+                                        <button :disabled="requestPage.name.includes('/')" type="button" class="btn btn-primary" @click="updateCreatePage">Continue</button>
                                     </div>
                                 </div>
                             </div>
@@ -273,6 +273,11 @@
             },
             updateCreatePage() {
                 let page = this.requestPage;
+
+                if (page.name.includes('/')) {
+                    return
+                }
+
                 if(page.parent === 'null') {
                     page.parent = null;
                 }


### PR DESCRIPTION
Not a complete page name check by any means, but disallows `/` as a page name as it won't do what the user thinks it will.