### PR TITLE
Disallow organization members where needed, and patch permission escalation

### DIFF
--- a/apiV2/app/controllers/apiv2/Organizations.scala
+++ b/apiV2/app/controllers/apiv2/Organizations.scala
@@ -40,7 +40,8 @@ class Organizations(
     ApiAction(Permission.ManageOrganizationMembers, APIScope.OrganizationScope(organization))
       .asyncF(parseCirce.decodeJson[List[Members.MemberUpdate]]) { implicit r =>
         Members.updateMembers[Organization, OrganizationUserRole, OrganizationRoleTable](
-          getOwner = organizations.withName(organization).someOrFail(NotFound),
+          getSubject = organizations.withName(organization).someOrFail(NotFound),
+          allowOrgMembers = false,
           getMembersQuery = APIV2Queries.projectMembers(organization, _, _),
           createRole = OrganizationUserRole(_, _, _),
           roleCompanion = OrganizationUserRole,

--- a/apiV2/app/controllers/apiv2/Projects.scala
+++ b/apiV2/app/controllers/apiv2/Projects.scala
@@ -289,7 +289,8 @@ class Projects(
     ApiAction(Permission.ManageProjectMembers, APIScope.ProjectScope(pluginId))
       .asyncF(parseCirce.decodeJson[List[Members.MemberUpdate]]) { implicit r =>
         Members.updateMembers[Project, ProjectUserRole, ProjectRoleTable](
-          getOwner = projects.withPluginId(pluginId).someOrFail(NotFound),
+          getSubject = projects.withPluginId(pluginId).someOrFail(NotFound),
+          allowOrgMembers = true,
           getMembersQuery = APIV2Queries.projectMembers(pluginId, _, _),
           createRole = ProjectUserRole(_, _, _),
           roleCompanion = ProjectUserRole,

--- a/oreClient/src/main/assets/components/MemberList.vue
+++ b/oreClient/src/main/assets/components/MemberList.vue
@@ -73,6 +73,7 @@
         <li v-if="permissions.includes('manage_subject_members') && editable" class="list-group-item">
           <user-search
             :exclude="Object.values(updatedMembers).map((m) => m.user)"
+            :exclude-organizations="excludeOrganizations"
             style="width: 100%;"
             @add-user="addNewMember"
           />
@@ -128,6 +129,10 @@ export default {
     commitLocation: {
       type: String,
       default: null,
+    },
+    excludeOrganizations: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {

--- a/oreClient/src/main/assets/components/UserSearch.vue
+++ b/oreClient/src/main/assets/components/UserSearch.vue
@@ -41,6 +41,10 @@ export default {
         return []
       },
     },
+    excludeOrganizations: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -58,7 +62,11 @@ export default {
       if (this.query === '') {
         this.users = []
       } else {
-        API.request('users?q=' + this.query + '&limit=' + 5).then((res) => {
+        API.request('users', 'GET', {
+          q: this.query,
+          limit: 5,
+          excludeOrganizations: this.excludeOrganizations,
+        }).then((res) => {
           this.users = res.result.filter((u) => !this.exclude.includes(u.name))
         })
       }

--- a/oreClient/src/main/assets/pages/user/UserProjects.vue
+++ b/oreClient/src/main/assets/pages/user/UserProjects.vue
@@ -115,6 +115,7 @@
           :members="orgaMembers"
           :permissions="orgaPermissions"
           editable
+          exclude-organizations
           new-role="Organization_Support"
           :endpoint="'users/' + user.name + '/members'"
           commit-location="user/updateMembers"


### PR DESCRIPTION
Orgs are not valid members of other orgs. They can be valid members of project for the purpose of setting them to owners.

Also makes sure that the IsOwner permission can never be set by editing roles. Also make sure that the one editing the roles also has all the perms involved (always the case currently, might not be if we ever add more roles)