### PR TITLE
Check user perms in scope if no API key is present

### DIFF
--- a/apiV2/app/controllers/apiv2/AbstractApiV2Controller.scala
+++ b/apiV2/app/controllers/apiv2/AbstractApiV2Controller.scala
@@ -100,7 +100,7 @@ abstract class AbstractApiV2Controller(lifecycle: ApplicationLifecycle)(
           .orElseFail(unAuth("Invalid session"))
         scopePerms <- {
           val res: IO[Result, Permission] =
-            apiScopeToRealScope(scope).flatMap(info.permissionIn).orElseFail(NotFound)
+            apiScopeToRealScope(scope).flatMap(info.permissionIn(_)).orElseFail(NotFound)
           res
         }
         res <- {

--- a/apiV2/app/controllers/apiv2/AbstractApiV2Controller.scala
+++ b/apiV2/app/controllers/apiv2/AbstractApiV2Controller.scala
@@ -86,10 +86,6 @@ abstract class AbstractApiV2Controller(lifecycle: ApplicationLifecycle)(
   def apiAction(scope: APIScope): ActionRefiner[Request, ApiRequest] = new ActionRefiner[Request, ApiRequest] {
     def executionContext: ExecutionContext = ec
 
-    def permissionIn(scope: Scope, apiInfo: ApiAuthInfo): UIO[Permission] =
-      if (scope == GlobalScope) ZIO.succeed(apiInfo.globalPerms)
-      else apiInfo.key.fold(ZIO.succeed(apiInfo.globalPerms))(_.permissionsIn(scope))
-
     override protected def refine[A](request: Request[A]): Future[Either[Result, ApiRequest[A]]] = {
       def unAuth(msg: String) = Unauthorized(ApiError(msg)).withHeaders(WWW_AUTHENTICATE -> "OreApi")
 
@@ -104,7 +100,7 @@ abstract class AbstractApiV2Controller(lifecycle: ApplicationLifecycle)(
           .orElseFail(unAuth("Invalid session"))
         scopePerms <- {
           val res: IO[Result, Permission] =
-            apiScopeToRealScope(scope).flatMap(permissionIn(_, info)).orElseFail(NotFound)
+            apiScopeToRealScope(scope).flatMap(info.permissionIn).orElseFail(NotFound)
           res
         }
         res <- {

--- a/orePlayCommon/app/controllers/sugar/Requests.scala
+++ b/orePlayCommon/app/controllers/sugar/Requests.scala
@@ -29,7 +29,16 @@ object Requests {
       session: Option[String],
       expires: OffsetDateTime,
       globalPerms: Permission
-  )
+  ) {
+
+    def permissionIn[B: HasScope, F[_]](b: B)(implicit service: ModelService[F], F: Applicative[F]): F[Permission] =
+      if (b.scope == GlobalScope) F.pure(globalPerms)
+      else
+        key
+          .map(_.permissionsIn(b))
+          .orElse(user.map(_.permissionsIn(b)))
+          .getOrElse(F.pure(globalPerms))
+  }
 
   case class ApiRequest[A](apiInfo: ApiAuthInfo, scopePermission: Permission, request: Request[A])
       extends WrappedRequest[A](request)
@@ -39,12 +48,7 @@ object Requests {
     def globalPermissions: Permission = apiInfo.globalPerms
 
     def permissionIn[B: HasScope, F[_]](b: B)(implicit service: ModelService[F], F: Applicative[F]): F[Permission] =
-      if (b.scope == GlobalScope) F.pure(apiInfo.globalPerms)
-      else
-        apiInfo.key
-          .map(_.permissionsIn(b))
-          .orElse(apiInfo.user.map(_.permissionsIn(b)))
-          .getOrElse(F.pure(globalPermissions))
+      apiInfo.permissionIn(b)
 
     override def logMessage(s: String): String = {
       user.foreach(mdcPutUser)


### PR DESCRIPTION
Currently we don't check the permissions of a user if we don't have an API key for their session. This fixes that