### PR TITLE
Fix home page showing twice for new projects

### DIFF
--- a/oreClient/src/main/assets/pages/project/ProjectDocs.vue
+++ b/oreClient/src/main/assets/pages/project/ProjectDocs.vue
@@ -220,7 +220,7 @@ export default {
       return jsRoutes.controllers.project
     },
     groupedPages() {
-      const nonHome = this.pages.filter((p) => p.slug.length !== 1 || p.slug[0] !== 'Home')
+      const nonHome = this.pages.filter((p) => p.slug.length !== 1 || p.slug[0].toLowerCase() !== 'home')
       const acc = {}
 
       for (const page of nonHome) {


### PR DESCRIPTION
The slug of the homepage for new projects is completely lowercase

We can look into the underlying problem later. This is just a quick fix.