### PR TITLE
Enable webpack monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ RUNNING_PID
 gradle
 .gradle
 build
+user.sbt
 
 # Hydra
 project/hydra.sbt

--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ cors {
 5. Use `yarn run start` to start the webpack dev server
 6. Navigate to `http://localhost:8080`
 
+#### Disable webpack monitoring
+By default, Ore will monitor the frontend for changes and rebuilt it whenever it sees any. If you're running Ore with 
+the webpack server, this can be more of a hinderance. If you wish to disable it, add this to a new file 
+called `user.sbt` in the root folder.
+```scala
+lazy val setNoMonitoredFiles: State => State = { s: State =>
+  val projectID = "oreClient"
+  val value = Nil
+  if (Project.extract(s).get(LocalProject(projectID) / Assets / webpackMonitoredDirectories) == value)
+    s
+  else
+    s"""set (LocalProject("$projectID") / Assets / webpackMonitoredDirectories) := $value""" :: s
+}
+
+Global / onLoad := {
+  val old = (Global / onLoad).value
+  setNoMonitoredFiles compose old
+}
+```
+
 ### Using Hydra
 
 Hydra is the world’s only parallel compiler for the Scala language.

--- a/build.sbt
+++ b/build.sbt
@@ -134,7 +134,7 @@ lazy val oreClient = project
     name := "ore-client",
     Assets / webpackDevConfig := baseDirectory.value / "webpack.config.dev.js",
     Assets / webpackProdConfig := baseDirectory.value / "webpack.config.prod.js",
-    //webpackMonitoredDirectories in Assets += baseDirectory.value / "src" / "main" / "assets",
+    Assets / webpackMonitoredDirectories += baseDirectory.value / "src" / "main" / "assets",
     Assets / webpackMonitoredFiles / includeFilter := "*.vue" || "*.js",
     webpackMonitoredFiles in Assets ++= Seq(
       baseDirectory.value / "webpack.config.common.js",


### PR DESCRIPTION
Enable webpack monitoring again, and add instructions on how to disable it. This is the safer setting, and should be the default