### PR TITLE
plugins.json -> sponge_plugins.json

### DIFF
--- a/orePlayCommon/app/ore/models/project/io/PluginFileData.scala
+++ b/orePlayCommon/app/ore/models/project/io/PluginFileData.scala
@@ -208,7 +208,7 @@ object ModTomlHandler extends FileTypeHandler("mod.toml") {
     Nil
 }
 
-object SpongeJsonHandler extends FileTypeHandler("META-INF/plugins.json") {
+object SpongeJsonHandler extends FileTypeHandler("META-INF/sponge_plugins.json") {
 
   override def getData(bufferedReader: BufferedReader): Seq[DataValue] = {
     try {


### PR DESCRIPTION
Forgot to update this, API-8 plugins now use `sponge_plugins.json`