### PR TITLE
Ensure input streams are not closed when finding meta files

### DIFF
--- a/orePlayCommon/app/ore/models/project/io/PluginFile.scala
+++ b/orePlayCommon/app/ore/models/project/io/PluginFile.scala
@@ -49,9 +49,11 @@ class PluginFile(val path: Path, val user: Model[User]) {
               .continually(jarIn.getNextJarEntry)
               .takeWhile(_ != null) // scalafix:ok
               .filter(entry => fileNames.contains(entry.getName))
-              .flatMap(entry => PluginFileData.getData(entry.getName, new BufferedReader(new InputStreamReader(jarIn)) {
-                override def close(): Unit = {}
-              }))
+              .flatMap(entry => {
+                PluginFileData.getData(entry.getName, new BufferedReader(new InputStreamReader(jarIn)) {
+                  override def close(): Unit = {}
+                })
+              })
               .toVector
 
             // Mainfest file isn't read in the jar stream for whatever reason

--- a/orePlayCommon/app/ore/models/project/io/PluginFile.scala
+++ b/orePlayCommon/app/ore/models/project/io/PluginFile.scala
@@ -49,11 +49,11 @@ class PluginFile(val path: Path, val user: Model[User]) {
               .continually(jarIn.getNextJarEntry)
               .takeWhile(_ != null) // scalafix:ok
               .filter(entry => fileNames.contains(entry.getName))
-              .flatMap(entry => {
+              .flatMap { entry =>
                 PluginFileData.getData(entry.getName, new BufferedReader(new InputStreamReader(jarIn)) {
                   override def close(): Unit = {}
                 })
-              })
+              }
               .toVector
 
             // Mainfest file isn't read in the jar stream for whatever reason

--- a/orePlayCommon/app/ore/models/project/io/PluginFile.scala
+++ b/orePlayCommon/app/ore/models/project/io/PluginFile.scala
@@ -49,7 +49,9 @@ class PluginFile(val path: Path, val user: Model[User]) {
               .continually(jarIn.getNextJarEntry)
               .takeWhile(_ != null) // scalafix:ok
               .filter(entry => fileNames.contains(entry.getName))
-              .flatMap(entry => PluginFileData.getData(entry.getName, new BufferedReader(new InputStreamReader(jarIn))))
+              .flatMap(entry => PluginFileData.getData(entry.getName, new BufferedReader(new InputStreamReader(jarIn)) {
+                override def close(): Unit = {}
+              }))
               .toVector
 
             // Mainfest file isn't read in the jar stream for whatever reason


### PR DESCRIPTION
plugin-meta 0.8 closes streams when it's read the metadata. We override the close() method to prevent that from happening.