### PR TITLE
Work around recommended version not being a restriction for deps

### DIFF
--- a/orePlayCommon/app/ore/models/project/io/PluginFileData.scala
+++ b/orePlayCommon/app/ore/models/project/io/PluginFileData.scala
@@ -232,6 +232,11 @@ object SpongeJsonHandler extends FileTypeHandler("META-INF/sponge_plugins.json")
   }
 
   def readDependencies(in: Iterable[PluginDependency]): Seq[Dependency] =
-    in.map(dep => Dependency(dep.id, Option.when(dep.version.hasRestrictions)(dep.version.toString))).toSeq
+    in.map { dep =>
+      Dependency(
+        dep.id,
+        Option.when(dep.version.hasRestrictions || dep.version.getRecommendedVersion != null)(dep.version.toString)
+      )
+    }.toSeq
 
 }


### PR DESCRIPTION
Last thing I hope!

In the maven artifact library, the recommended version is not considered a restriction for some reason. We still want to display that recommended version though. This manifests as not displaying the version for the deps.