### PR TITLE
Don't use exact query when getting projects by namespace

### DIFF
--- a/oreClient/src/main/assets/stores/project.js
+++ b/oreClient/src/main/assets/stores/project.js
@@ -81,15 +81,22 @@ const actions = {
       })
     }
   },
-  setActiveProject(context, project) {
+  async setActiveProject(context, project) {
     if (!context.state.project || !isEqual(context.state.project.namespace, project)) {
-      API.request('projects?exact=true&owner=' + project.owner + '&q=' + project.slug).then((res) => {
-        if (res.result.length) {
-          context.dispatch('setActiveProjectFromFetched', res.result[0])
-        } else {
+      let res
+      try {
+        res = await API.projectRequest(project)
+      } catch (e) {
+        if (e === 404) {
           context.dispatch('projectNotFound')
+        } else {
+          throw e
         }
-      })
+      }
+
+      if (res) {
+        context.dispatch('setActiveProjectFromFetched', res)
+      }
     }
   },
 }


### PR DESCRIPTION
IIRC exact is a relic from when the API worked on plugin ids, not project namespaces, when looking up projects. We don't need to use exact here anymore